### PR TITLE
Correct copyright and license

### DIFF
--- a/CitadelService/Platform/CitadelCore.Windows/ByteArrayExtensions.cs
+++ b/CitadelService/Platform/CitadelCore.Windows/ByteArrayExtensions.cs
@@ -1,5 +1,5 @@
-﻿/*
-* Copyright � 2018 Cloudveil Technology Inc.  
+/*
+* Copyright © 2017-Present Jesse Nicholson
 * This Source Code Form is subject to the terms of the Mozilla Public
 * License, v. 2.0. If a copy of the MPL was not distributed with this
 * file, You can obtain one at http://mozilla.org/MPL/2.0/.


### PR DESCRIPTION
The copyright was incorrectly changed on this file.    This file is a copy of https://github.com/TechnikEmpire/CitadelCore/blob/master/CitadelCore/Extensions/ByteArrayExtensions.cs